### PR TITLE
Moved used props out of spread for React 15.2.x

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,8 +4,8 @@ import React from 'react';
 const DOMParser = typeof window !== 'undefined' && window.DOMParser;
 const process = process || {};
       process.env = process.env || {};
-const parserAvailable = typeof DOMParser !== 'undefined' && 
-                        DOMParser.prototype != null && 
+const parserAvailable = typeof DOMParser !== 'undefined' &&
+                        DOMParser.prototype != null &&
                         DOMParser.prototype.parseFromString != null;
 
 if ("production" !== process.env.NODE_ENV && !parserAvailable) {
@@ -80,7 +80,7 @@ export default class InlineSVG extends React.Component {
 
     render() {
         let Element, __html, svgProps;
-        const { element, raw, src } = this.props;
+        const { element, raw, src, ...otherProps } = this.props;
 
         if (raw === true && isParsable(src)) {
             Element = 'svg';
@@ -91,7 +91,7 @@ export default class InlineSVG extends React.Component {
         Element = Element || element;
         svgProps = svgProps || {};
 
-        return <Element {...svgProps} {...this.props} src={null} children={null}
+        return <Element {...svgProps} {...otherProps} src={null} children={null}
                         dangerouslySetInnerHTML={{ __html }} />
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svg-inline-react",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Inline SVG wrapper component for React",
   "main": "dist/index.js",
   "jsnext:main": "es/index.js",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/sairion/svg-inline-react",
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0-rc.1"
+    "react": "^0.14.0 || ^15.0.0"
   },
   "devDependencies": {
     "babel": "^5.8.34",


### PR DESCRIPTION
This PR addresses the React 15.2.x update that throws errors from unknown-prop:  https://fb.me/react-unknown-prop

I don't think any of the props removed with the spread are necessary in Element.  So it should be fine.   Tested on my own project successfully.

Please let me know if there are any issues.

Issue: https://github.com/sairion/svg-inline-react/issues/8
