### PR TITLE
add engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
   },
   "dependencies": {
     "prop-types": "^15.5.0"
+  },
+  "engines": {
+    "node": ">=4"
   }
 }


### PR DESCRIPTION
This module is written in es6 so only node >= 4 support it well natively.