### PR TITLE
Add support for React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/sairion/svg-inline-react",
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.23.1",


### PR DESCRIPTION
I'm using this package with React 16 with no issues. I think it's safe to add it as a valid peerDependency