### PR TITLE
Remove unsafe componentWillReceiveProps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,8 @@ import { getSVGFromSource, extractSVGProps } from './util';
 const process = process || { env: {} };
 
 export default class InlineSVG extends React.Component {
-    componentWillReceiveProps({ children }) {
+    componentDidMount() {
+        const { children } = this.props;
         if ("production" !== process.env.NODE_ENV && children != null) {
             console.info('<InlineSVG />: `children` prop will be ignored.');
         }


### PR DESCRIPTION
With the new lifecycle React API `componentWillReceiveProps` is going to be deprecated. With the new version 16.9, there is a warning for `componentWillReceiveProps`.

There is two solutions. The easiest is to replace `componentWillReceiveProps` with `UNSAFE_componentWillReceiveProps`. The other is to replace the `componentWillReceiveProps` with a new lifecycle method.
Here I replaced with `componentDidMount`.