### PR TITLE
Allow use with React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/sairion/svg-inline-react",
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0" || ^17.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.23.1",


### PR DESCRIPTION
It works great with React 17 for us, which is expected since v17 really didn't introduce any new features or breaking changes -- https://reactjs.org/blog/2020/10/20/react-v17.html